### PR TITLE
Add batchSize to aggregation calls

### DIFF
--- a/tests/Aggregation/GroupTest.php
+++ b/tests/Aggregation/GroupTest.php
@@ -61,7 +61,7 @@ class GroupTest extends AbstractTestCase
         $sum->setSum(1);
         $group->setResultField('count', $sum);
 
-        $result = $this->collection->aggregate([$group->getStage()]);
+        $result = $this->collection->aggregate([$group->getStage()], ['cursor' => ['batchSize' => 101]]);
 
         $foos = 0;
         $bars = 0;
@@ -106,7 +106,7 @@ class GroupTest extends AbstractTestCase
         $sum->setSum(1);
         $group->setResultField('count', $sum);
 
-        $result = $this->collection->aggregate([$group->getStage()]);
+        $result = $this->collection->aggregate([$group->getStage()], ['cursor' => ['batchSize' => 101]]);
 
         $this->assertEquals(3, count($result['result']));
 

--- a/tests/Aggregation/LimitTest.php
+++ b/tests/Aggregation/LimitTest.php
@@ -31,7 +31,7 @@ class LimitTest extends AbstractTestCase
         $limit = new Limit();
         $limit->setLimit(2);
 
-        $result = $this->collection->aggregate([$limit->getStage()]);
+        $result = $this->collection->aggregate([$limit->getStage()], ['cursor' => ['batchSize' => 101]]);
 
         $this->assertEquals(2, count($result['result']), 'Asserting the amount of returned results is limited to the amount of the added Limit stage.');
     }
@@ -54,7 +54,7 @@ class LimitTest extends AbstractTestCase
 
         $limit = new Limit(2);
 
-        $result = $this->collection->aggregate([$limit->getStage()]);
+        $result = $this->collection->aggregate([$limit->getStage()], ['cursor' => ['batchSize' => 101]]);
 
         $this->assertEquals(2, count($result['result']), 'Asserting the amount of returned results is limited to the amount of the added Limit stage.');
     }

--- a/tests/Aggregation/MatchTest.php
+++ b/tests/Aggregation/MatchTest.php
@@ -32,7 +32,7 @@ class MatchTest extends AbstractTestCase
         $match = new Match();
         $match->setQuery(['foo' => 'foo']);
 
-        $result = $this->collection->aggregate([$match->getStage()]);
+        $result = $this->collection->aggregate([$match->getStage()], ['cursor' => ['batchSize' => 101]]);
 
         $this->assertEquals(2, count($result['result']));
     }

--- a/tests/Aggregation/ProjectionTest.php
+++ b/tests/Aggregation/ProjectionTest.php
@@ -33,7 +33,7 @@ class ProjectionTest extends AbstractTestCase
         $projection = new Projection();
         $projection->includeField('foo');
 
-        $result = $this->collection->aggregate([$projection->getStage()]);
+        $result = $this->collection->aggregate([$projection->getStage()], ['cursor' => ['batchSize' => 101]]);
 
         $this->assertEquals(5, count($result['result']));
     }
@@ -64,7 +64,7 @@ class ProjectionTest extends AbstractTestCase
         );
         $projection->includeOperationField('isFoo', $condition);
 
-        $result = $this->collection->aggregate([$projection->getStage()]);
+        $result = $this->collection->aggregate([$projection->getStage()], ['cursor' => ['batchSize' => 101]]);
 
         $this->assertEquals(5, count($result['result']));
 

--- a/tests/Aggregation/RangeProjectionTest.php
+++ b/tests/Aggregation/RangeProjectionTest.php
@@ -41,7 +41,7 @@ class RangeProjectionTest extends AbstractTestCase
         $rangedProjection = new RangeProjection();
         $rangedProjection->addRange('foo', $ranges);
 
-        $result = $this->collection->aggregate([$rangedProjection->getStage()]);
+        $result = $this->collection->aggregate([$rangedProjection->getStage()], ['cursor' => ['batchSize' => 101]]);
 
         $this->assertEquals(count($testData), count($result['result']));
         $lows = 0;

--- a/tests/Aggregation/SkipTest.php
+++ b/tests/Aggregation/SkipTest.php
@@ -30,7 +30,7 @@ class SkipTest extends AbstractTestCase
         $skip = new Skip();
         $skip->setAmount(1);
 
-        $result = $this->collection->aggregate([$skip->getStage()]);
+        $result = $this->collection->aggregate([$skip->getStage()], ['cursor' => ['batchSize' => 101]]);
 
         $this->assertEquals('2', $result['result'][0]['foo'], 'Asserting results are skipped equal to the amount added Skip stage.');
     }
@@ -52,7 +52,7 @@ class SkipTest extends AbstractTestCase
 
         $skip = new Skip(1);
 
-        $result = $this->collection->aggregate([$skip->getStage()]);
+        $result = $this->collection->aggregate([$skip->getStage()], ['cursor' => ['batchSize' => 101]]);
 
         $this->assertEquals('2', $result['result'][0]['foo'], 'Asserting results are skipped equal to the amount added Skip stage.');
     }

--- a/tests/Aggregation/SortTest.php
+++ b/tests/Aggregation/SortTest.php
@@ -33,7 +33,7 @@ class SortTest extends AbstractTestCase
         $sort = new Sort();
         $sort->addSort('foo', -1);
 
-        $result = $this->collection->aggregate([$sort->getStage()]);
+        $result = $this->collection->aggregate([$sort->getStage()], ['cursor' => ['batchSize' => 101]]);
 
         $max = 500;
         foreach ($result['result'] as $record) {

--- a/tests/Aggregation/UnwindTest.php
+++ b/tests/Aggregation/UnwindTest.php
@@ -29,7 +29,7 @@ class UnwindTest extends AbstractTestCase
         $unwind = new Unwind();
         $unwind->setField('foo');
 
-        $result = $this->collection->aggregate([$unwind->getStage()]);
+        $result = $this->collection->aggregate([$unwind->getStage()], ['cursor' => ['batchSize' => 101]]);
 
         $this->assertEquals(4, count($result['result']));
     }

--- a/tests/Builder/PipelineBuilderTest.php
+++ b/tests/Builder/PipelineBuilderTest.php
@@ -51,7 +51,7 @@ class PipelineBuilderTest extends PHPUnit_Framework_TestCase
         $unwind3->setField('baz');
 
         $bag = new AggregationBag();
-        $bag->addAggregation($unwind2);
+        $bag->addAggregation($unwind2, ['cursor' => ['batchSize' => 101]]);
 
         $builder = new PipelineBuilder();
         $builder->add($unwind3);

--- a/tests/Builder/UnwindBuilderTest.php
+++ b/tests/Builder/UnwindBuilderTest.php
@@ -72,7 +72,7 @@ class UnwindBuilderTest extends AbstractTestCase
 
         $pipeline = $builder->build();
 
-        $result = $this->collection->aggregate($pipeline);
+        $result = $this->collection->aggregate($pipeline, ['cursor' => ['batchSize' => 101]]);
 
         $foos = 0;
         $bars = 0;

--- a/tests/Operation/WeekOperationTest.php
+++ b/tests/Operation/WeekOperationTest.php
@@ -58,7 +58,7 @@ class WeekOperationTest extends AbstractTestCase
         $projection->includeField('expected');
         $projection->includeOperationField('weeknumber', $week);
 
-        $result = $this->collection->aggregate([$projection->getStage()]);
+        $result = $this->collection->aggregate([$projection->getStage()], ['cursor' => ['batchSize' => 101]]);
 
         $this->assertEquals(3, count($result['result']));
 


### PR DESCRIPTION
Since mongo 3.6 adding this is required.
https://www.php.net/manual/en/mongocollection.aggregatecursor.php#options states the default size is 101.